### PR TITLE
Support for ignoring fields in a struct

### DIFF
--- a/hood.go
+++ b/hood.go
@@ -743,10 +743,17 @@ func interfaceToModel(f interface{}) (*Model, error) {
 	}
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
+
+		// omit tag
+		sqltag := field.Tag.Get("sql")
+		if sqltag == "-" {
+			continue
+		}
+
 		fd := &Field{
 			Name:         toSnake(field.Name),
 			Value:        v.FieldByName(field.Name).Interface(),
-			SqlTags:      parseTags(field.Tag.Get("sql")),
+			SqlTags:      parseTags(sqltag),
 			ValidateTags: parseTags(field.Tag.Get("validate")),
 		}
 		if fd.PrimaryKey() {

--- a/hood_test.go
+++ b/hood_test.go
@@ -114,6 +114,17 @@ func TestFieldValidate(t *testing.T) {
 	}
 }
 
+func TestFieldOmit(t *testing.T) {
+	type Schema struct {
+		A string `sql:"-"`
+		B string
+	}
+	m, _ := interfaceToModel(&Schema{})
+	if x := len(m.Fields); x != 1 {
+		t.Fatal("wrong len", x)
+	}
+}
+
 type validateSchema struct {
 	A string
 }


### PR DESCRIPTION
Hi again, 

I hit a snag when I was trying to override the default name of a struct's xml element. 

``` go
type Person struct {
    XMLName xml.Name `sql:"-" xml:"person" json:"-"`
    Id hood.Id `xml:"id,attr" json:"id"`
    FirstName string `validate:"presence" xml:"name>first" json:"first_name"`
    LastName hood.VarChar `sql:"size(128),notnull" xml:"name>last" json:"last_name"`
    Updated time.Time `xml:"dateUpdated" json:"date_updated"`
}
```

Previously the existence of the XMLName field would cause a panic: invalid sql type.

Seeing as the only purpose of the XMLName field is to override behaviour specific to xml un/marshalling, I added a flag to the sql tag (based on the convention used in the json tag) allowing hood to ignore the field.

feedback is appreciated, this is my first go at go.
