### PR TITLE
Handle embedded fields in models

### DIFF
--- a/hood_test.go
+++ b/hood_test.go
@@ -168,6 +168,29 @@ func TestValidationMethods(t *testing.T) {
 	}
 }
 
+// test interfacetomodel with an embedded struct
+func TestInterfaceToModelWithEmbedded(t *testing.T) {
+	type embed struct {
+		Name  string
+		Value string
+	}
+	type table struct {
+		ColPrimary Id
+		embed
+	}
+	table1 := &table{
+		6, embed{"Mrs. A", "infinite"},
+	}
+	m, err := interfaceToModel(table1)
+	if err != nil {
+		t.Fatal("error not nil", err)
+	}
+	f := m.Fields[1]
+	if x, ok := f.Value.(string); !ok || x != "Mrs. A" {
+		t.Fatal("wrong value from embedded struct")
+	}
+}
+
 func TestInterfaceToModel(t *testing.T) {
 	type table struct {
 		ColPrimary    Id

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -10,8 +10,8 @@ import (
 func init() {
 	// It's probably not a good idea to register the dialect by default since
 	// it requires specific packages to be installed on the target system!
-	// 
-	// RegisterDialect("sqlite3", &Sqlite3{})
+	//
+	// RegisterDialect("sqlite3", NewSqlite3())
 }
 
 type Sqlite3 struct {


### PR DESCRIPTION
Hi,

Wondering if you'd be interested in the following change to interfaceToModel to handle embedded fields in the model. I moved the field extraction out to its own function and recursively call it for embedded fields. It does not currently handle duplicate fieldnames, I'm not entirely sure how to handle it yet.

I've also changed the comment about how to register the sqlite3 dialect since I spent quite awhile trying to figure out what I did wrong after commenting that one in.

cheers, Ulf
