### PR TITLE
support mapping string type to VARCHAR

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -50,6 +50,9 @@ func (d *Mysql) SqlType(f interface{}, size int) string {
 	case []byte:
 		return "longblob"
 	case string:
+		if size > 0 && size < 65532 {
+			return fmt.Sprintf("varchar(%d)", size)
+		}
 		return "longtext"
 	}
 	panic("invalid sql type")


### PR DESCRIPTION
if size is defined, we can map string type to SQL VARCHAR type,
without the need to cast between string and hood.VarChar.
