### PR TITLE
Fix: db:migrate may fail if extra files in db/migrations (e.g. backups).

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -241,6 +241,11 @@ func runMigrations(steps int32) {
 			continue
 		}
 
+		// Skip non-go files
+		if !strings.HasSuffix(file.Name(), ".go") {
+			continue
+		}
+
 		// Copy
 		dstFile := path.Join(tmpDir, file.Name())
 		_, err = copyFile(


### PR DESCRIPTION
Only .go files to be copied from db/migrations to hood-migration temporary directory for compilation.

Fixes #59
