### PR TITLE
Use github.com/lib/pq (currently being maintained)

### DIFF
--- a/dialects_test.go
+++ b/dialects_test.go
@@ -15,7 +15,7 @@ import (
 // INFO IN THE TO_RUN ARRAY!
 
 import (
-	_ "github.com/bmizerany/pq"
+	_ "github.com/lib/pq"
 	_ "github.com/ziutek/mymysql/godrv"
 )
 

--- a/postgres.go
+++ b/postgres.go
@@ -2,7 +2,7 @@ package hood
 
 import (
 	"fmt"
-	_ "github.com/bmizerany/pq"
+	_ "github.com/lib/pq"
 	"strings"
 	"time"
 )


### PR DESCRIPTION
Blake announced on the golang-nuts list a while ago that future work on pq would be done at `github.com/lib/pq`. I ran the tests against the updated driver and all passed.
