### PR TITLE
Add support for sql null types

### DIFF
--- a/base.go
+++ b/base.go
@@ -1,6 +1,7 @@
 package hood
 
 import (
+	"database/sql"
 	"fmt"
 	"reflect"
 	"strings"
@@ -67,6 +68,21 @@ func (d *base) SetModelValue(driverValue, fieldValue reflect.Value) error {
 			} else {
 				panic(fmt.Sprintf("cannot set created value %T", driverValue.Elem().Interface()))
 			}
+		} else if fieldType == reflect.TypeOf(sql.NullBool{}) {
+			if b, ok := driverValue.Elem().Interface().(bool); ok {
+				fieldValue.Set(reflect.ValueOf(sql.NullBool{b, true}))
+			}
+		} else if fieldType == reflect.TypeOf(sql.NullFloat64{}) {
+			if f, ok := driverValue.Elem().Interface().(float64); ok {
+				fieldValue.Set(reflect.ValueOf(sql.NullFloat64{f, true}))
+			}
+		} else if fieldType == reflect.TypeOf(sql.NullInt64{}) {
+			if i, ok := driverValue.Elem().Interface().(int64); ok {
+				fieldValue.Set(reflect.ValueOf(sql.NullInt64{i, true}))
+			}
+		} else if fieldType == reflect.TypeOf(sql.NullString{}) {
+			str := string(driverValue.Elem().Bytes())
+			fieldValue.Set(reflect.ValueOf(sql.NullString{str, true}))
 		}
 	}
 	return nil

--- a/mysql.go
+++ b/mysql.go
@@ -1,6 +1,7 @@
 package hood
 
 import (
+	"database/sql"
 	"fmt"
 	"reflect"
 	"time"
@@ -38,20 +39,20 @@ func (d *mysql) SqlType(f interface{}, size int) string {
 		return "bigint"
 	case time.Time, Created, Updated:
 		return "timestamp"
-	case bool:
+	case bool, sql.NullBool:
 		return "boolean"
 	case int, int8, int16, int32, uint, uint8, uint16, uint32:
 		return "int"
-	case int64, uint64:
+	case int64, uint64, sql.NullInt64:
 		return "bigint"
-	case float32, float64:
+	case float32, float64, sql.NullFloat64:
 		return "double"
 	case []byte:
 		if size > 0 && size < 65532 {
 			return fmt.Sprintf("varbinary(%d)", size)
 		}
 		return "longblob"
-	case string:
+	case string, sql.NullString:
 		if size > 0 && size < 65532 {
 			return fmt.Sprintf("varchar(%d)", size)
 		}

--- a/postgres.go
+++ b/postgres.go
@@ -1,6 +1,7 @@
 package hood
 
 import (
+	"database/sql"
 	"fmt"
 	_ "github.com/lib/pq"
 	"strings"
@@ -27,17 +28,17 @@ func (d *postgres) SqlType(f interface{}, size int) string {
 		return "bigserial"
 	case time.Time, Created, Updated:
 		return "timestamp with time zone"
-	case bool:
+	case bool, sql.NullBool:
 		return "boolean"
 	case int, int8, int16, int32, uint, uint8, uint16, uint32:
 		return "integer"
-	case int64, uint64:
+	case int64, uint64, sql.NullInt64:
 		return "bigint"
-	case float32, float64:
+	case float32, float64, sql.NullFloat64:
 		return "double precision"
 	case []byte:
 		return "bytea"
-	case string:
+	case string, sql.NullString:
 		if size > 0 && size < 65532 {
 			return fmt.Sprintf("varchar(%d)", size)
 		}


### PR DESCRIPTION
This pull request adds Null\* types from the database/sql package to the Hood SQL Types and adds support for the types in SetModelValue. I've tested the changes with both mysql and postgresql. Everything looks to be working as expected. This will allow hood to handle values which may be null.

---

Example:

``` go
type Test struct {
    Id       hood.Id
    Number   sql.NullInt64
}

// Connect and Start Transaction

a = Test{}
tx.Save(&a) //Number column is set to NULL in database (defaults to NULL)

b = Test{}
b.Number = sql.NullInt64{128, true} //Number column is set to 128 in database
tx.Save(&b)

c = Test{}
c.Number = sql.NullInt64{128, false} //Number column is set to NULL in database since valid bool is set to false
tx.Save(&c)
```

Retrieving the row which was inserted by tx.Save(&c) above will give you a sql.NullInt64{0, false} for Number

---

Question: Since normal types (int, string, etc) can't represent a null value, should the notnull keyword be removed and assumed to be not null unless the column type is of type NullBool, NullInt64, etc?
