### PR TITLE
Add ability to define foreign keys in models

### DIFF
--- a/base.go
+++ b/base.go
@@ -300,6 +300,15 @@ func (d *base) CreateTableSql(model *Model, ifNotExists bool) string {
 			a = append(a, ", ")
 		}
 	}
+	if len(model.ForeignKeys) > 0 {
+		a = append(a, ", ")
+	}
+	for i, fk := range model.ForeignKeys {
+		a = append(a, d.Dialect.ForeignKey(fk))
+		if i < len(model.ForeignKeys)-1 {
+			a = append(a, ", ")
+		}
+	}
 	a = append(a, " )")
 	return strings.Join(a, "")
 }
@@ -433,4 +442,31 @@ func (d *base) KeywordPrimaryKey() string {
 
 func (d *base) KeywordAutoIncrement() string {
 	return "AUTOINCREMENT"
+}
+
+func (d *base) ForeignKey(fk *ForeignKey) string {
+	return fmt.Sprintf(
+		"FOREIGN KEY (%v) REFERENCES %v(%v) ON UPDATE %s ON DELETE %s",
+		d.Dialect.Quote(fk.Column),
+		d.Dialect.Quote(fk.ReferenceTable),
+		d.Dialect.Quote(fk.ReferenceColumn),
+		d.Dialect.ReferentialAction(fk.OnUpdate),
+		d.Dialect.ReferentialAction(fk.OnDelete),
+	)
+
+}
+
+func (d *base) ReferentialAction(ra ReferentialAction) string {
+	switch ra {
+	case Cascade:
+		return "CASCADE"
+	case Restrict:
+		return "RESTRICT"
+	case NoAction:
+		return "NO ACTION"
+	case SetNull:
+		return "SET NULL"
+	}
+
+	return "NO ACTION"
 }

--- a/base.go
+++ b/base.go
@@ -446,7 +446,7 @@ func (d *base) KeywordAutoIncrement() string {
 
 func (d *base) ForeignKey(fk *ForeignKey) string {
 	return fmt.Sprintf(
-		"FOREIGN KEY (%v) REFERENCES %v(%v) ON UPDATE %s ON DELETE %s",
+		"FOREIGN KEY (%v) REFERENCES %v(%v) ON UPDATE %v ON DELETE %v",
 		d.Dialect.Quote(fk.Column),
 		d.Dialect.Quote(fk.ReferenceTable),
 		d.Dialect.Quote(fk.ReferenceColumn),

--- a/dialect.go
+++ b/dialect.go
@@ -130,4 +130,10 @@ type Dialect interface {
 
 	// KeywordAutoIncrement returns the dialect specific keyword for 'AUTO_INCREMENT'.
 	KeywordAutoIncrement() string
+
+	// ForeignKey returns the dialect spefific foreign key constraint
+	ForeignKey(fk *ForeignKey) string
+
+	// ReferentialAction returns the dialect spefific foreign key referntial action
+	ReferentialAction(ra ReferentialAction) string
 }

--- a/hood.go
+++ b/hood.go
@@ -391,6 +391,18 @@ func (index *Index) GoDeclaration() string {
 	)
 }
 
+func (foreignKey *ForeignKey) GoDeclaration() string {
+	return fmt.Sprintf(
+		"foreignKeys.Add(\"%s\", \"%s\", \"%s\", \"%s\", %s, %s)",
+		foreignKey.Name,
+		foreignKey.Column,
+		foreignKey.ReferenceTable,
+		foreignKey.ReferenceColumn,
+		foreignKey.OnUpdate,
+		foreignKey.OnDelete,
+	)
+}
+
 func (model *Model) Validate() error {
 	for _, field := range model.Fields {
 		err := field.Validate()
@@ -414,6 +426,15 @@ func (model *Model) GoDeclaration() string {
 		)
 		for _, i := range model.Indexes {
 			a = append(a, "\t"+i.GoDeclaration())
+		}
+		a = append(a, "}")
+	}
+	if len(model.ForeignKeys) > 0 {
+		a = append(a,
+			fmt.Sprintf("\nfunc (table *%s) ForeignKeys(foreignKeys *hood.ForeignKeys) {", tableName),
+		)
+		for _, fk := range model.ForeignKeys {
+			a = append(a, "\t"+fk.GoDeclaration())
 		}
 		a = append(a, "}")
 	}


### PR DESCRIPTION
Adds a ForeignKeyed interface similar to the Index interface for defining foreign keys in models. (It only supports single column foreign keys)

---

Example Schemas

``` go
type User struct {
    Id   hood.Id
    Name string
}

type Post struct {
    Id      hood.Id
    Content string
    UserId  int64
}

func (table *Post) ForeignKeys(foreignKeys *hood.ForeignKeys) {
    foreignKeys.Add("test_fk", "user_id", "user", "id", hood.Cascade, hood.Cascade)
}
```

---

I added a ReferentialAction type. Cascase, Restrict, NoAction, and SetNull are constants defined. It follows the same pattern that Join does.

The function signature for foreignKeys.Add is 

``` go
Add(name string, column string, referenceTable string, referenceColumn string, onUpdate ReferentialAction, onDelete ReferentialAction)
```

name: Name of foreign key constraint
column: The column in the table/model to create the foreign key on
referenceTable: The name of the table with the column the foreign key will reference
referenceColumn: The column in the referenceTable the foreign key will reference

Two functions were added to dialect.go: ForeignKey and ReferentialAction.

Foreign keys are created when the table is created.
