### PR TITLE
Adds FindOne

### DIFF
--- a/dialects_test.go
+++ b/dialects_test.go
@@ -619,6 +619,89 @@ func DoTestFind(t *testing.T, info dialectInfo) {
 	}
 }
 
+func TestFindOne(t *testing.T) {
+	for _, info := range toRun {
+		DoTestFindOne(t, info)
+	}
+}
+
+func DoTestFindOne(t *testing.T, info dialectInfo) {
+	t.Logf("Dialect %T\n", info.dialect)
+	hd := info.setupDbFunc(t)
+
+	type findOneModel struct {
+		Id Id
+		A  string
+		B  int
+	}
+
+	model1 := findOneModel{
+		A: "string!",
+		B: 2,
+	}
+
+	hd.DropTable(&model1)
+
+	tx := hd.Begin()
+	tx.CreateTable(&model1)
+	err := tx.Commit()
+	if err != nil {
+		t.Fatal("error not nil", err)
+	}
+
+	// Test with no data (should be empty)
+
+	// Test with struct
+	var out findOneModel
+	err = hd.Where("a", "=", "string!").And("b", "=", 2).FindOne(&out)
+	if err != nil {
+		t.Fatal("error not nil", err)
+	}
+	if out.Id != 0 || out.A != "" || out.B != 0 {
+		t.Fatal("struct should be zeroed", out)
+	}
+
+	// Test with pointer to struct
+	var out2 *findOneModel
+	err = hd.Where("a", "=", "string!").And("b", "=", 2).FindOne(&out)
+	if err != nil {
+		t.Fatal("error not nil", err)
+	}
+	if out2 != nil {
+		t.Fatal("ptr should be nil", out)
+	}
+
+	// Insert a row, test again:
+	id, err := hd.Save(&model1)
+	if err != nil {
+		t.Fatal("error not nil", err)
+	}
+	if id != 1 {
+		t.Fatal("wrong id", id)
+	}
+
+	// Test with struct
+	err = hd.Where("a", "=", "string!").And("b", "=", 2).FindOne(&out)
+	if err != nil {
+		t.Fatal("error not nil", err)
+	}
+	if out.Id != 1 || out.A != "string!" || out.B != 2 {
+		t.Fatal("struct is not expected", out)
+	}
+
+	// Test with pointer to struct
+	err = hd.Where("a", "=", "string!").And("b", "=", 2).FindOne(&out2)
+	if err != nil {
+		t.Fatal("error not nil", err)
+	}
+	if out2 == nil {
+		t.Fatal("ptr should not be nil", out2)
+	}
+	if out2.Id != 1 || out2.A != "string!" || out2.B != 2 {
+		t.Fatal("struct is not expected", out)
+	}
+}
+
 func TestCreateTable(t *testing.T) {
 	for _, info := range toRun {
 		DoTestCreateTable(t, info)

--- a/hood.go
+++ b/hood.go
@@ -692,12 +692,12 @@ func (hood *Hood) Find(out interface{}) error {
 	query, args := hood.Dialect.QuerySql(hood)
 	return hood.FindSql(out, query, args...)
 }
-func (hood *Hood) FindOne(out interface{})error{
-    if hood.selectTable == ""{
-        hood.Select(out)
-    }
-    query, args := hood.Dialect.QuerySql(hood)
-    return hood.FindOneSql(out,query,args...)
+func (hood *Hood) FindOne(out interface{}) error {
+	if hood.selectTable == "" {
+		hood.Select(out)
+	}
+	query, args := hood.Dialect.QuerySql(hood)
+	return hood.FindOneSql(out, query, args...)
 }
 func (hood *Hood) FindOneSql(out interface{}, query string, args ...interface{}) error {
 	hood.mutex.Lock()
@@ -738,7 +738,7 @@ func (hood *Hood) FindOneSql(out interface{}, query string, args ...interface{})
 			return err
 		}
 		// create a new row and fill
-		rowValue := reflect.New(reflect.TypeOf(outValue))
+		rowValue := reflect.New(outValue.Type())
 		for i, v := range containers {
 			key := cols[i]
 			value := reflect.Indirect(reflect.ValueOf(v))
@@ -751,8 +751,9 @@ func (hood *Hood) FindOneSql(out interface{}, query string, args ...interface{})
 				}
 			}
 		}
-        outValue.Set(rowValue)
-        break;
+
+		outValue.Set(rowValue.Elem())
+		break
 	}
 	return nil
 }

--- a/hood.go
+++ b/hood.go
@@ -692,6 +692,70 @@ func (hood *Hood) Find(out interface{}) error {
 	query, args := hood.Dialect.QuerySql(hood)
 	return hood.FindSql(out, query, args...)
 }
+func (hood *Hood) FindOne(out interface{})error{
+    if hood.selectTable == ""{
+        hood.Select(out)
+    }
+    query, args := hood.Dialect.QuerySql(hood)
+    return hood.FindOneSql(out,query,args...)
+}
+func (hood *Hood) FindOneSql(out interface{}, query string, args ...interface{}) error {
+	hood.mutex.Lock()
+	defer hood.mutex.Unlock()
+	defer hood.Reset()
+
+	panicMsg := errors.New("expected pointer to struct")
+	if x := reflect.TypeOf(out).Kind(); x != reflect.Ptr {
+		panic(panicMsg)
+	}
+	outValue := reflect.Indirect(reflect.ValueOf(out))
+	if x := outValue.Kind(); x != reflect.Struct {
+		panic(panicMsg)
+	}
+	hood.logSql(query, args...)
+	stmt, err := hood.qo.Prepare(query)
+	if err != nil {
+		return hood.updateTxError(err)
+	}
+	defer stmt.Close()
+	rows, err := stmt.Query(args...)
+	if err != nil {
+		return hood.updateTxError(err)
+	}
+	defer rows.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		return hood.updateTxError(err)
+	}
+	for rows.Next() {
+		containers := make([]interface{}, 0, len(cols))
+		for i := 0; i < cap(containers); i++ {
+			var v interface{}
+			containers = append(containers, &v)
+		}
+		err := rows.Scan(containers...)
+		if err != nil {
+			return err
+		}
+		// create a new row and fill
+		rowValue := reflect.New(reflect.TypeOf(outValue))
+		for i, v := range containers {
+			key := cols[i]
+			value := reflect.Indirect(reflect.ValueOf(v))
+			name := snakeToUpperCamel(key)
+			field := rowValue.Elem().FieldByName(name)
+			if field.IsValid() {
+				err = hood.Dialect.SetModelValue(value, field)
+				if err != nil {
+					return err
+				}
+			}
+		}
+        outValue.Set(rowValue)
+        break;
+	}
+	return nil
+}
 
 // FindSql performs a find using the specified custom sql query and arguments and
 // writes the results to the specified out interface{}.


### PR DESCRIPTION
This adds a FindOne method, fixing some bugs with the FindOne in #57 and adding the flexibility to pass in both a pointer to a struct and a pointer to a pointer to a struct as an out value.  

Example usage is shown in the test I included.
